### PR TITLE
fixed vm_rpn_compare_A_B such that using beq on it's result will bran…

### DIFF
--- a/appData/src/gb/src/core/asm/nes/vm_6502asm.s
+++ b/appData/src/gb/src/core/asm/nes/vm_6502asm.s
@@ -818,8 +818,15 @@ _vm_rpn_asm::
 .vm_rpn_compare_A_B:
     sec
     sbc .vm_rpn_B_lo,x
+    sta .vm_rpn_B_lo,x
     tya
     sbc .vm_rpn_B_hi,x
+    sta .vm_rpn_B_hi,x
+    lda .vm_rpn_B_lo,x
+    lsr .vm_rpn_B_lo,x
+    ora .vm_rpn_B_lo,x
+    and #254
+    ora .vm_rpn_B_hi,x
     rts
 
 ;


### PR DESCRIPTION
…ch only if A and B are equal.

The result of vm_rpn_compare_A_B previously only returned the high byte of it's 16-bit subtraction in the accumulator. Because of this whenever the beq instruction is used in an rpn comparison it is unable to see any differences between A and B smaller than positive 255. This patch makes vm_rpn_compare_A_B combine the low and high bytes in the accumulator such that it will only be 0 if all 16-bits of the subtraction are 0 while preserving the 8th-bit to only be 1 when the result is negative.

This fixes the behavior of "==", "<", "=>", and "!=" comparison operators in if statements within the in-editor scripting language since they get compiled down to gbvm rpn comparisons.
