### PR TITLE
Rpn hardcoded bitshifts

### DIFF
--- a/appData/src/gb/src/core/asm/nes/vm_6502asm.s
+++ b/appData/src/gb/src/core/asm/nes/vm_6502asm.s
@@ -318,11 +318,11 @@ _vm_rpn_asm::
 .db <.vm_rpn_op_ILLEGAL
 
 ; Hard-coded SHL/SHR/ASR
-.db <.vm_rpn_op_TODO        ; SHL4 (0x10)
+.db <.vm_rpn_op_SHL4        ; SHL4 (0x10)
 .db <.vm_rpn_op_SHL7        ; SHL7 (0x11)
-.db <.vm_rpn_op_TODO        ; SHR4 (0x12)
-.db <.vm_rpn_op_TODO        ; SHR7 (0x13)
-.db <.vm_rpn_op_TODO        ; ASR4 (0x14)
+.db <.vm_rpn_op_SHR4        ; SHR4 (0x12)
+.db <.vm_rpn_op_SHR7        ; SHR7 (0x13)
+.db <.vm_rpn_op_ASR4        ; ASR4 (0x14)
 .db <.vm_rpn_op_ASR7        ; ASR7 (0x15)
 .db <.vm_rpn_op_CLAMP0      ; CLAMP0 (0x16)
 
@@ -411,11 +411,11 @@ _vm_rpn_asm::
 .db >.vm_rpn_op_ILLEGAL
 
 ; Hard-coded SHL/SHR/ASR
-.db >.vm_rpn_op_TODO        ; SHL4 (0x10)
+.db >.vm_rpn_op_SHL4        ; SHL4 (0x10)
 .db >.vm_rpn_op_SHL7        ; SHL7 (0x11)
-.db >.vm_rpn_op_TODO        ; SHR4 (0x12)
-.db >.vm_rpn_op_TODO        ; SHR7 (0x13)
-.db >.vm_rpn_op_TODO        ; ASR4 (0x14)
+.db >.vm_rpn_op_SHR4        ; SHR4 (0x12)
+.db >.vm_rpn_op_SHR7        ; SHR7 (0x13)
+.db >.vm_rpn_op_ASR4        ; ASR4 (0x14)
 .db >.vm_rpn_op_ASR7        ; ASR7 (0x15)
 .db >.vm_rpn_op_CLAMP0      ; CLAMP0 (0x16)
 
@@ -741,6 +741,61 @@ _vm_rpn_asm::
     lda #0xFF
 1$:
     sta .vm_rpn_B_hi,x
+    jmp .vm_rpn_op_next
+
+.vm_rpn_op_SHR7:
+    lda .vm_rpn_B_lo,x
+    asl
+    lda .vm_rpn_B_hi,x
+    rol
+    sta .vm_rpn_B_lo,x
+    lda #0
+    rol
+    sta .vm_rpn_B_hi,x
+    jmp .vm_rpn_op_next
+
+
+.vm_rpn_op_ASR4: ; 54 cycles
+    lda .vm_rpn_B_hi,x 
+    lsr
+    ror .vm_rpn_B_lo,x
+    lsr
+    ror .vm_rpn_B_lo,x
+    lsr
+    ror .vm_rpn_B_lo,x
+    lsr
+    ror .vm_rpn_B_lo,x 
+    cmp #0x08 
+    bcc 1$ 
+    ora #0xF0 
+1$:
+    sta .vm_rpn_B_hi,x 
+    jmp .vm_rpn_op_next 
+
+.vm_rpn_op_SHR4: ; 47 cycles
+    lda .vm_rpn_B_hi,x
+    lsr
+    ror .vm_rpn_B_lo,x
+    lsr
+    ror .vm_rpn_B_lo,x
+    lsr
+    ror .vm_rpn_B_lo,x
+    lsr
+    ror .vm_rpn_B_lo,x
+    sta .vm_rpn_B_hi,x
+    jmp .vm_rpn_op_next
+
+.vm_rpn_op_SHL4: ; 47 cycles
+    lda .vm_rpn_B_lo,x
+    asl
+    rol .vm_rpn_B_hi,x
+    asl
+    rol .vm_rpn_B_hi,x
+    asl
+    rol .vm_rpn_B_hi,x
+    asl
+    rol .vm_rpn_B_hi,x
+    sta .vm_rpn_B_lo,x
     jmp .vm_rpn_op_next
 
 .vm_rpn_op_SHL:

--- a/appData/src/gb/src/core/asm/nes/vm_6502asm.s
+++ b/appData/src/gb/src/core/asm/nes/vm_6502asm.s
@@ -318,11 +318,11 @@ _vm_rpn_asm::
 .db <.vm_rpn_op_ILLEGAL
 
 ; Hard-coded SHL/SHR/ASR
-.db <.vm_rpn_op_SHL4        ; SHL4 (0x10)
+.db <.vm_rpn_op_TODO        ; SHL4 (0x10)
 .db <.vm_rpn_op_SHL7        ; SHL7 (0x11)
-.db <.vm_rpn_op_SHR4        ; SHR4 (0x12)
-.db <.vm_rpn_op_SHR7        ; SHR7 (0x13)
-.db <.vm_rpn_op_ASR4        ; ASR4 (0x14)
+.db <.vm_rpn_op_TODO        ; SHR4 (0x12)
+.db <.vm_rpn_op_TODO        ; SHR7 (0x13)
+.db <.vm_rpn_op_TODO        ; ASR4 (0x14)
 .db <.vm_rpn_op_ASR7        ; ASR7 (0x15)
 .db <.vm_rpn_op_CLAMP0      ; CLAMP0 (0x16)
 
@@ -411,11 +411,11 @@ _vm_rpn_asm::
 .db >.vm_rpn_op_ILLEGAL
 
 ; Hard-coded SHL/SHR/ASR
-.db >.vm_rpn_op_SHL4        ; SHL4 (0x10)
+.db >.vm_rpn_op_TODO        ; SHL4 (0x10)
 .db >.vm_rpn_op_SHL7        ; SHL7 (0x11)
-.db >.vm_rpn_op_SHR4        ; SHR4 (0x12)
-.db >.vm_rpn_op_SHR7        ; SHR7 (0x13)
-.db >.vm_rpn_op_ASR4        ; ASR4 (0x14)
+.db >.vm_rpn_op_TODO        ; SHR4 (0x12)
+.db >.vm_rpn_op_TODO        ; SHR7 (0x13)
+.db >.vm_rpn_op_TODO        ; ASR4 (0x14)
 .db >.vm_rpn_op_ASR7        ; ASR7 (0x15)
 .db >.vm_rpn_op_CLAMP0      ; CLAMP0 (0x16)
 
@@ -741,61 +741,6 @@ _vm_rpn_asm::
     lda #0xFF
 1$:
     sta .vm_rpn_B_hi,x
-    jmp .vm_rpn_op_next
-
-.vm_rpn_op_SHR7:
-    lda .vm_rpn_B_lo,x
-    asl
-    lda .vm_rpn_B_hi,x
-    rol
-    sta .vm_rpn_B_lo,x
-    lda #0
-    rol
-    sta .vm_rpn_B_hi,x
-    jmp .vm_rpn_op_next
-
-
-.vm_rpn_op_ASR4: ; 54 cycles
-    lda .vm_rpn_B_hi,x 
-    lsr
-    ror .vm_rpn_B_lo,x
-    lsr
-    ror .vm_rpn_B_lo,x
-    lsr
-    ror .vm_rpn_B_lo,x
-    lsr
-    ror .vm_rpn_B_lo,x 
-    cmp #0x08 
-    bcc 1$ 
-    ora #0xF0 
-1$:
-    sta .vm_rpn_B_hi,x 
-    jmp .vm_rpn_op_next 
-
-.vm_rpn_op_SHR4: ; 47 cycles
-    lda .vm_rpn_B_hi,x
-    lsr
-    ror .vm_rpn_B_lo,x
-    lsr
-    ror .vm_rpn_B_lo,x
-    lsr
-    ror .vm_rpn_B_lo,x
-    lsr
-    ror .vm_rpn_B_lo,x
-    sta .vm_rpn_B_hi,x
-    jmp .vm_rpn_op_next
-
-.vm_rpn_op_SHL4: ; 47 cycles
-    lda .vm_rpn_B_lo,x
-    asl
-    rol .vm_rpn_B_hi,x
-    asl
-    rol .vm_rpn_B_hi,x
-    asl
-    rol .vm_rpn_B_hi,x
-    asl
-    rol .vm_rpn_B_hi,x
-    sta .vm_rpn_B_lo,x
     jmp .vm_rpn_op_next
 
 .vm_rpn_op_SHL:

--- a/src/components/forms/ValueSelect.tsx
+++ b/src/components/forms/ValueSelect.tsx
@@ -119,6 +119,7 @@ const iconLookup: Record<
   // bitwise
   shl: <TextIcon>&lt;&lt;</TextIcon>,
   shl7: <TextIcon>shl7</TextIcon>,
+  shl4: <TextIcon>shl4</TextIcon>,
   shr: <TextIcon>&gt;&gt;</TextIcon>,
   bAND: <TextIcon>&amp;</TextIcon>,
   bOR: <TextIcon>|</TextIcon>,
@@ -161,6 +162,7 @@ const l10nKeyLookup: Record<
   isqrt: "FIELD_SQUARE_ROOT",
   rnd: "FIELD_RANDOM",
   shl7: "FIELD_NUMBER",
+  shl4: "FIELD_NUMBER",
   // bitwise
   shl: "FIELD_LEFT_SHIFT",
   shr: "FIELD_RIGHT_SHIFT",

--- a/src/components/forms/ValueSelect.tsx
+++ b/src/components/forms/ValueSelect.tsx
@@ -120,6 +120,8 @@ const iconLookup: Record<
   shl: <TextIcon>&lt;&lt;</TextIcon>,
   shl7: <TextIcon>shl7</TextIcon>,
   shl4: <TextIcon>shl4</TextIcon>,
+  shr7: <TextIcon>shr7</TextIcon>,
+  shr4: <TextIcon>shr4</TextIcon>,
   shr: <TextIcon>&gt;&gt;</TextIcon>,
   bAND: <TextIcon>&amp;</TextIcon>,
   bOR: <TextIcon>|</TextIcon>,
@@ -163,6 +165,8 @@ const l10nKeyLookup: Record<
   rnd: "FIELD_RANDOM",
   shl7: "FIELD_NUMBER",
   shl4: "FIELD_NUMBER",
+  shr7: "FIELD_NUMBER",
+  shr4: "FIELD_NUMBER",
   // bitwise
   shl: "FIELD_LEFT_SHIFT",
   shr: "FIELD_RIGHT_SHIFT",

--- a/src/lib/compiler/scriptBuilder.ts
+++ b/src/lib/compiler/scriptBuilder.ts
@@ -574,6 +574,8 @@ const valueFunctionToScriptOperator = (
       return ".B_NOT";
     case "shl7":
       return ".SHL7";
+    case "shl4":
+      return ".SHL4";
     case "rnd":
       return ".RND";
   }
@@ -1451,7 +1453,7 @@ class ScriptBuilder {
             this._rpn() //
               .ref(this._localRef(actorRef, 1))
               //.int16(7)
-              .operator(".ASR7") //.operator(".ASR")
+              .operator(".ASR4") //.operator(".ASR")
               .refSet(localVar)
               .stop();
           } else if (propertyValue === "pypos") {
@@ -1463,7 +1465,7 @@ class ScriptBuilder {
             this._rpn() //
               .ref(this._localRef(actorRef, 2))
               //.int16(7)
-              .operator(".ASR7") //.operator(".ASR")
+              .operator(".ASR4") //.operator(".ASR")
               .refSet(localVar)
               .stop();
           } else if (propertyValue === "direction") {

--- a/src/lib/compiler/scriptBuilder.ts
+++ b/src/lib/compiler/scriptBuilder.ts
@@ -576,6 +576,10 @@ const valueFunctionToScriptOperator = (
       return ".SHL7";
     case "shl4":
       return ".SHL4";
+    case "shr7":
+      return ".SHL7";
+    case "shr4":
+      return ".SHL4";
     case "rnd":
       return ".RND";
   }

--- a/src/shared/lib/scriptValue/format.ts
+++ b/src/shared/lib/scriptValue/format.ts
@@ -147,6 +147,10 @@ export const scriptValueToString = (
     return `~(${scriptValueToString(value.value, options)})`;
   } else if (value.type === "shl4") {
     return `~(${scriptValueToString(value.value, options)})`;
+  } else if (value.type === "shr7") {
+    return `~(${scriptValueToString(value.value, options)})`;
+  } else if (value.type === "shr4") {
+    return `~(${scriptValueToString(value.value, options)})`;
   } else if (value.type === "abs") {
     return `abs(${scriptValueToString(value.value, options)})`;
   } else if (value.type === "isqrt") {

--- a/src/shared/lib/scriptValue/format.ts
+++ b/src/shared/lib/scriptValue/format.ts
@@ -145,6 +145,8 @@ export const scriptValueToString = (
     return `~(${scriptValueToString(value.value, options)})`;
   } else if (value.type === "shl7") {
     return `~(${scriptValueToString(value.value, options)})`;
+  } else if (value.type === "shl4") {
+    return `~(${scriptValueToString(value.value, options)})`;
   } else if (value.type === "abs") {
     return `abs(${scriptValueToString(value.value, options)})`;
   } else if (value.type === "isqrt") {

--- a/src/shared/lib/scriptValue/helpers.ts
+++ b/src/shared/lib/scriptValue/helpers.ts
@@ -184,6 +184,16 @@ export const optimiseScriptValue = (input: ScriptValue): ScriptValue => {
           type: "number",
           value: (optimisedValue.value << 4),
         };
+      } else if (type === "shr7") {
+        return {
+          type: "number",
+          value: (optimisedValue.value >> 7),
+        };
+      } else if (type === "shr4") {
+        return {
+          type: "number",
+          value: (optimisedValue.value >> 4),
+        };
       } else if (type === "rnd") {
         return {
           type: "rnd",
@@ -588,6 +598,18 @@ export const shiftRightScriptValueConst = (
   value: ScriptValue,
   num: number
 ): ScriptValue => {
+if(num == 7) {
+  return {
+    type: "shr7",
+    value,
+  };  
+}
+if(num == 4) {
+  return {
+    type: "shr4",
+    value,
+  };  
+} else {
   return {
     type: "shr",
     valueA: value,
@@ -596,6 +618,7 @@ export const shiftRightScriptValueConst = (
       value: num,
     },
   };
+}
 };
 
 export const addScriptValueConst = (

--- a/src/shared/lib/scriptValue/helpers.ts
+++ b/src/shared/lib/scriptValue/helpers.ts
@@ -179,6 +179,11 @@ export const optimiseScriptValue = (input: ScriptValue): ScriptValue => {
           type: "number",
           value: (optimisedValue.value << 7),
         };
+      } else if (type === "shl4") {
+        return {
+          type: "number",
+          value: (optimisedValue.value << 4),
+        };
       } else if (type === "rnd") {
         return {
           type: "rnd",
@@ -559,6 +564,12 @@ export const shiftLeftScriptValueConst = (
 if(num == 7) {
   return {
     type: "shl7",
+    value,
+  };  
+}
+if(num == 4) {
+  return {
+    type: "shl4",
     value,
   };  
 } else {

--- a/src/shared/lib/scriptValue/types.ts
+++ b/src/shared/lib/scriptValue/types.ts
@@ -46,7 +46,7 @@ export const valueUnaryOperatorTypes = [
   // Bitwise
   "bNOT",
   // Special-case-shifts
-  //"shl4",
+  "shl4",
   "shl7",
   //"shr4",
   //"shr7",

--- a/src/shared/lib/scriptValue/types.ts
+++ b/src/shared/lib/scriptValue/types.ts
@@ -48,8 +48,8 @@ export const valueUnaryOperatorTypes = [
   // Special-case-shifts
   "shl4",
   "shl7",
-  //"shr4",
-  //"shr7",
+  "shr4",
+  "shr7",
   //"asr4",
   //"asr7",
 ] as const;


### PR DESCRIPTION
Added implementations for `SHL4`, `SHR4`, `ASR4`, and `SHR7` rpn operations. I spent a while trying to come up with an optimized algorithm for shifts by 4 but couldn't find anything much better than the naive approach. 

`SHL4`, `SHR4`, `SHR7` are also optimized into event scripts in the same way that left shifts by 7 would be optimized to `SHL7` when converted to GVBM. 

Also fixed a bug that affected the `ActorSetPositionRelative` event where the current position would be fetched as the position in tiles no matter if the actor is being moved by pixels or tiles. I found the bug occurs in `_performFetchOperations` function, I'm unsure if this bug impacted any other events but suspect it likely did.